### PR TITLE
Feat: Add heading tests for page components

### DIFF
--- a/src/app/clients/clients.component.spec.ts
+++ b/src/app/clients/clients.component.spec.ts
@@ -5,6 +5,7 @@ import { ClientsComponent } from "./clients.component";
 describe("ClientsComponent", () => {
   let component: ClientsComponent;
   let fixture: ComponentFixture<ClientsComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,9 +15,15 @@ describe("ClientsComponent", () => {
     fixture = TestBed.createComponent(ClientsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("h1");
+    expect(header?.innerText.trim()).toBe("Contact Directory");
   });
 });

--- a/src/app/commission/commission.component.spec.ts
+++ b/src/app/commission/commission.component.spec.ts
@@ -5,6 +5,7 @@ import { CommissionComponent } from "./commission.component";
 describe("CommissionComponent", () => {
   let component: CommissionComponent;
   let fixture: ComponentFixture<CommissionComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,9 +15,15 @@ describe("CommissionComponent", () => {
     fixture = TestBed.createComponent(CommissionComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("h1");
+    expect(header?.innerText.trim()).toBe("Commission Us");
   });
 });

--- a/src/app/contracts/contracts.component.spec.ts
+++ b/src/app/contracts/contracts.component.spec.ts
@@ -5,6 +5,7 @@ import { ContractsComponent } from "./contracts.component";
 describe("ContractsComponent", () => {
   let component: ContractsComponent;
   let fixture: ComponentFixture<ContractsComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,9 +15,15 @@ describe("ContractsComponent", () => {
     fixture = TestBed.createComponent(ContractsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("h1");
+    expect(header?.innerText.trim()).toBe("Completed Contracts");
   });
 });

--- a/src/app/donate/donate.component.spec.ts
+++ b/src/app/donate/donate.component.spec.ts
@@ -5,6 +5,7 @@ import { DonateComponent } from "./donate.component";
 describe("DonateComponent", () => {
   let component: DonateComponent;
   let fixture: ComponentFixture<DonateComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,9 +15,15 @@ describe("DonateComponent", () => {
     fixture = TestBed.createComponent(DonateComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("h1");
+    expect(header?.innerText.trim()).toBe("Support our Work");
   });
 });

--- a/src/app/former/former.component.spec.ts
+++ b/src/app/former/former.component.spec.ts
@@ -5,6 +5,7 @@ import { FormerComponent } from "./former.component";
 describe("FormerComponent", () => {
   let component: FormerComponent;
   let fixture: ComponentFixture<FormerComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,9 +15,15 @@ describe("FormerComponent", () => {
     fixture = TestBed.createComponent(FormerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("h1");
+    expect(header?.innerText.trim()).toBe("Archived Contacts");
   });
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -5,6 +5,7 @@ import { HomeComponent } from "./home.component";
 describe("HomeComponent", () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,9 +15,15 @@ describe("HomeComponent", () => {
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("h1");
+    expect(header?.innerText.trim()).toBe("Welcome");
   });
 });

--- a/src/app/input/input.component.spec.ts
+++ b/src/app/input/input.component.spec.ts
@@ -5,6 +5,7 @@ import { InputComponent } from "./input.component";
 describe("InputComponent", () => {
   let component: InputComponent;
   let fixture: ComponentFixture<InputComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,9 +15,15 @@ describe("InputComponent", () => {
     fixture = TestBed.createComponent(InputComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("span");
+    expect(header?.innerText.trim()).toBe("$>");
   });
 });

--- a/src/app/projects/projects.component.spec.ts
+++ b/src/app/projects/projects.component.spec.ts
@@ -5,6 +5,7 @@ import { ProjectsComponent } from "./projects.component";
 describe("ProjectsComponent", () => {
   let component: ProjectsComponent;
   let fixture: ComponentFixture<ProjectsComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,9 +15,15 @@ describe("ProjectsComponent", () => {
     fixture = TestBed.createComponent(ProjectsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("h1");
+    expect(header?.innerText.trim()).toBe("Personal Projects");
   });
 });

--- a/src/app/seekrit/seekrit.component.spec.ts
+++ b/src/app/seekrit/seekrit.component.spec.ts
@@ -6,6 +6,7 @@ import { SeekritComponent } from "./seekrit.component";
 describe("SeekritComponent", () => {
   let component: SeekritComponent;
   let fixture: ComponentFixture<SeekritComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -15,9 +16,15 @@ describe("SeekritComponent", () => {
     fixture = TestBed.createComponent(SeekritComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("div");
+    expect(header?.innerText.trim()).toBe("Nothing to see here...");
   });
 });

--- a/src/app/team/team.component.spec.ts
+++ b/src/app/team/team.component.spec.ts
@@ -5,6 +5,7 @@ import { TeamComponent } from "./team.component";
 describe("TeamComponent", () => {
   let component: TeamComponent;
   let fixture: ComponentFixture<TeamComponent>;
+  let compiled: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,9 +15,15 @@ describe("TeamComponent", () => {
     fixture = TestBed.createComponent(TeamComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    compiled = fixture.nativeElement;
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render correctly", () => {
+    const header = compiled.querySelector("h1");
+    expect(header?.innerText.trim()).toBe("Staff Directory");
   });
 });


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

<!--A brief description of what your pull request does.-->
This sets up the necessary testing infrastructure for the following page components: Clients, Commission, Donate, Former, Home, Projects, and Team. They all get a compiled element that is assigned before each test and a basic test of checking the page's title is performed. 


## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #298

As I don't know what simple tests you're interested in for the Seekrit and Input components, I don't want to consider it closed when this merges. 
